### PR TITLE
Remove Amplitude integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,4 @@ REACT_APP_ADMIN_PANEL_HOME_URL=https://old.akatsuki.gg
 REACT_APP_GITHUB_ORG_URL=https://github.com/osuAkatsuki
 REACT_APP_TWITTER_URL=https://twitter.com/akatsuki_osu
 REACT_APP_DISCORD_INVITE_URL=https://discord.com/invite/5cBtMPW
-REACT_APP_AMPLITUDE_API_KEY=
 REACT_APP_CLARITY_PROJECT_ID=

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "preinstall": "npx only-allow yarn"
   },
   "dependencies": {
-    "@amplitude/analytics-browser": "^2.9.3",
     "@babel/core": "^7.16.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import * as amplitude from "@amplitude/analytics-browser"
 import Box from "@mui/material/Box"
 import CssBaseline from "@mui/material/CssBaseline"
 import Stack from "@mui/material/Stack"
@@ -82,11 +81,6 @@ const router = createBrowserRouter(
 )
 
 export default function App() {
-  amplitude.init(process.env.REACT_APP_AMPLITUDE_API_KEY, {
-    defaultTracking: false,
-    minIdLength: 4,
-  })
-
   const theme = React.useMemo(
     () =>
       createTheme({

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,3 @@
-import * as amplitude from "@amplitude/analytics-browser"
 import {
   Alert,
   Autocomplete,
@@ -86,7 +85,6 @@ export const AuthenticationSettingsMenu = ({
       return
     }
 
-    amplitude.setUserId(String(identity.userId))
     setLoading(false)
     setServerError("")
     setIdentity(identity)
@@ -327,7 +325,6 @@ export const ProfileSettingsMenu = ({
     } catch (e: any) {
       console.error("Failed to logout on API:", e)
     }
-    amplitude.reset()
     setIdentity(null)
   }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,7 +15,6 @@ declare namespace NodeJS {
     readonly REACT_APP_GITHUB_ORG_URL: string
     readonly REACT_APP_TWITTER_URL: string
     readonly REACT_APP_DISCORD_INVITE_URL: string
-    readonly REACT_APP_AMPLITUDE_API_KEY: string
     readonly REACT_APP_CLARITY_PROJECT_ID: string
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,54 +12,6 @@
   resolved "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
-"@amplitude/analytics-browser@^2.9.3":
-  version "2.9.3"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.9.3.tgz"
-  integrity sha512-PnkJrJGRUfdE9nFgQZbWvUjNGnbcFojQROfj7KQeKGJTzQZXMt+xafmfXWDnhsf0JRgbk273Wh7Z6WNXxS1seA==
-  dependencies:
-    "@amplitude/analytics-client-common" "^2.2.4"
-    "@amplitude/analytics-core" "^2.3.0"
-    "@amplitude/analytics-types" "^2.6.0"
-    "@amplitude/plugin-page-view-tracking-browser" "^2.2.17"
-    tslib "^2.4.1"
-
-"@amplitude/analytics-client-common@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.2.4.tgz"
-  integrity sha512-+zOW3/Yb4LzK1DfhFCnSOcb8vgeZgIQffLM6yrgzKGedtQOnwDQeKTDI3aaMzckXQPVcJs1M6bJcT/l5TmAkDw==
-  dependencies:
-    "@amplitude/analytics-connector" "^1.4.8"
-    "@amplitude/analytics-core" "^2.3.0"
-    "@amplitude/analytics-types" "^2.6.0"
-    tslib "^2.4.1"
-
-"@amplitude/analytics-connector@^1.4.8":
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz"
-  integrity sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g==
-
-"@amplitude/analytics-core@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.3.0.tgz"
-  integrity sha512-Knafvocs29cPOHM3GHyBkP4nXUrh/oXnj2fULoSyh/03Bt63UPoyQCNS/EtQB/dOUhapTP35ZU9yZnrY+jvndQ==
-  dependencies:
-    "@amplitude/analytics-types" "^2.6.0"
-    tslib "^2.4.1"
-
-"@amplitude/analytics-types@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.6.0.tgz"
-  integrity sha512-7MSENvLCTGjec7K45JT+RcOuoPTCvq1MMq/HRLiQK/BMR4taX7f/uXldEc8b//o+ZZP45IBqFroR7Bl8LwJQrQ==
-
-"@amplitude/plugin-page-view-tracking-browser@^2.2.17":
-  version "2.2.17"
-  resolved "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.2.17.tgz"
-  integrity sha512-s19LUuPMvOhvM/36XOUeVSMGOhtSOPA6bhhrR4x/lEsyylsS+rfi6/fILd2B5gojplXKMvVlJXEP+t1fjIr1HA==
-  dependencies:
-    "@amplitude/analytics-client-common" "^2.2.4"
-    "@amplitude/analytics-types" "^2.6.0"
-    tslib "^2.4.1"
-
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz"
@@ -9170,7 +9122,7 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.4.1:
+tslib@^2.0.3:
   version "2.5.3"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz"
   integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==


### PR DESCRIPTION
## Summary
- Remove `@amplitude/analytics-browser` dependency from package.json and yarn.lock
- Remove Amplitude initialization from `App.tsx`
- Remove `amplitude.setUserId()` on login and `amplitude.reset()` on logout from `Navbar.tsx`
- Remove `REACT_APP_AMPLITUDE_API_KEY` from `.env.example` and `types.d.ts`

## Test plan
- [ ] Verify the app builds successfully
- [ ] Verify login/logout flows work without errors
- [ ] Verify no console errors related to missing Amplitude references

🤖 Generated with [Claude Code](https://claude.com/claude-code)