### PR TITLE
Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/deploy-deploy.yml
+++ b/.github/workflows/deploy-deploy.yml
@@ -16,22 +16,22 @@ jobs:
 
     steps:
       - name: Check out latest commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: osuAkatsuki/akatsuki-web
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -49,7 +49,7 @@ jobs:
           chmod 600 $HOME/.kube/config
 
       - name: Install helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v5
         with:
           version: "v3.19.2"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
         run: helm plugin install https://github.com/databus23/helm-diff
 
       - name: Checkout common-helm-charts repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           repository: osuAkatsuki/common-helm-charts
           token: ${{ secrets.COMMON_HELM_CHARTS_PAT_2024 }}


### PR DESCRIPTION
Updates GitHub Actions dependencies to current Node 24-compatible major versions to avoid the Node 20 deprecation warning now emitted by GitHub-hosted runners.

Mechanical workflow-only changes:
- actions/checkout -> v7
- docker/login-action -> v4
- docker/metadata-action -> v6
- docker/build-push-action -> v7
- docker/setup-qemu-action -> v4
- docker/setup-buildx-action -> v4
- actions/setup-python -> v6
- actions/upload-artifact -> v7
- actions/download-artifact -> v8
- hashicorp/setup-terraform -> v4
- actions/github-script -> v9
- azure/setup-helm -> v5

Validation: `git diff --check`.
